### PR TITLE
Make runnable from terminal

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,5 +13,5 @@ git clone https://github.com/Hixon10/grpc-nginx.git ./grpc-nginx
 cd grpc-nginx
 docker-compose up -d
 
-curl http://localhost:81
+curl http://localhost:81/top
 ```

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -1,15 +1,5 @@
-FROM openjdk:8
+FROM gradle:4.5.1-jdk8
 
-RUN mkdir -p /client/
+CMD ["gradle", "bootRun"]
 
-COPY . /client
-
-WORKDIR /client
-
-RUN chmod 777 /client/gradlew
-
-RUN ./gradlew test build
-
-CMD ["./gradlew", "bootRun"]
-
-EXPOSE 81
+EXPOSE 8080

--- a/client/src/main/java/ru/hixon/movieclient/GrpcConfiguration.java
+++ b/client/src/main/java/ru/hixon/movieclient/GrpcConfiguration.java
@@ -11,8 +11,7 @@ public class GrpcConfiguration {
 
     @Bean
     public ManagedChannel managedChannel() {
-//        return ManagedChannelBuilder.forAddress("nginx", 80)
-        return ManagedChannelBuilder.forAddress("localhost", 6565)
+        return ManagedChannelBuilder.forAddress("nginx", 80)
                 .usePlaintext(true)
                 .build();
     }

--- a/client/src/main/resources/application.properties
+++ b/client/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-server.port=81

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,30 +1,36 @@
 version: '3'
 services:
   nginx:
-    depends_on:  
-      - movie    
+    depends_on:
+      - movie
     container_name: nginx-with-grpc
     image: nginx:1.13.10
     restart: always
     ports:
     - 80:80
-    - 443:443    
+    - 443:443
     volumes:
-    - ./nginx/conf.d:/etc/nginx/conf.d     
-    - ./nginx/logs:/etc/nginx/logs       
+    - ./nginx/conf.d:/etc/nginx/conf.d
+    - ./nginx/logs:/etc/nginx/logs
 
-  movie:  
+  movie:
     container_name: movie
     build: ./movies
     hostname: movie
-    restart: always   
+    restart: always
     ports:
-      - 6565:6565     
+      - 6565:6565
+    volumes:
+      - ./movies:/home/gradle/project
+    working_dir: /home/gradle/project
 
   client:
     container_name: client
     build: ./client
     hostname: client
-    restart: always   
+    restart: always
     ports:
-      - 81:81              
+      - 81:8080
+    volumes:
+      - ./client:/home/gradle/project
+    working_dir: /home/gradle/project

--- a/movies/Dockerfile
+++ b/movies/Dockerfile
@@ -1,15 +1,5 @@
-FROM openjdk:8
+FROM gradle:4.5.1-jdk8
 
-RUN mkdir -p /movie/
-
-COPY . /movie
-
-WORKDIR /movie
-
-RUN chmod 777 /movie/gradlew
-
-RUN ./gradlew test build
-
-CMD ["./gradlew", "bootRun"]
+CMD ["gradle", "bootRun"]
 
 EXPOSE 6565

--- a/nginx/logs/access.log
+++ b/nginx/logs/access.log
@@ -1,3 +1,0 @@
-172.21.0.2 - - [25/Mar/2018:18:09:51 +0000] "POST /MoviesRating/GetRating HTTP/2.0" 200 470 "-" "grpc-java-netty/1.10.0"
-172.21.0.2 - - [25/Mar/2018:18:09:52 +0000] "POST /MoviesRating/GetRating HTTP/2.0" 200 470 "-" "grpc-java-netty/1.10.0"
-172.21.0.2 - - [25/Mar/2018:18:09:55 +0000] "POST /MoviesRating/GetRating HTTP/2.0" 200 470 "-" "grpc-java-netty/1.10.0"


### PR DESCRIPTION
1. update url from localhost to nginx: localhost is not available from within docker container
1. use gradle:4.5.1-jdk8 image and gradle command
1. use standard port 8080 for spring boot app and redirect it later to 81 in docker-compose
1. remove logs as they will be automatically recreated by nginx
1. update readme to call `/top`